### PR TITLE
feat: fix zerops deployment

### DIFF
--- a/deployments.ts
+++ b/deployments.ts
@@ -139,7 +139,7 @@ export const deployments = [
   },
   {
     name: "Zerops",
-    url: "",
+    url: "https://app-ba-3000.prg1.zerops.app",
     dash: "https://app.zerops.io/",
     docs: "https://nitro.unjs.io/deploy/providers/zerops",
   },

--- a/zerops.yml
+++ b/zerops.yml
@@ -8,12 +8,10 @@ zerops:
         - pnpm i
         - pnpm run build
       deployFiles:
-        - .output
-        - package.json
-        - node_modules
+        - .output/~
     run:
       base: nodejs@20
       ports:
         - port: 3000
           httpSupport: true
-      start: node .output/server/index.mjs
+      start: node server/index.mjs


### PR DESCRIPTION
Hey team, as you have your own zerops account with credits. Feel free to deploy it on your side to have the control.

You can just import this whole repo via this import yml on the Zerops dashboard.

```yml
project:
  name: nitrojs

services:
  - hostname: app
    type: nodejs@20
    enableSubdomainAccess: true
    buildFromGit: https://github.com/nitrojs/nitro-deploys
 
```

After it builds successfully you can go to the app service then to public access to enable subdomain.

Then you can just utilize that link wherever you need :)


Changes Made
- Improved zerops.yml as node_modules & package.json are unnecessary.
- Added the link for the deployment testing (replace with your own)
