### PR TITLE
ci: bump node version to LTS

### DIFF
--- a/.github/workflows/alwaysdata.yml
+++ b/.github/workflows/alwaysdata.yml
@@ -14,7 +14,7 @@ jobs:
       - run: npm i -fg corepack && corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: lts/*
           cache: pnpm
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,7 +13,7 @@ jobs:
       - run: npm i -fg corepack && corepack enable
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: lts/*
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm automd

--- a/genezio.yaml
+++ b/genezio.yaml
@@ -8,7 +8,7 @@ backend:
   path: .output/
   language:
     name: js
-    runtime: nodejs20.x
+    runtime: nodejs22.x
     packageManager: pnpm
   functions:
     - name: server


### PR DESCRIPTION
I think we can bump node version to lts since node 22 is stable.